### PR TITLE
Improve handling of timeouts

### DIFF
--- a/src/backend/communication/playerHandler.ts
+++ b/src/backend/communication/playerHandler.ts
@@ -168,7 +168,7 @@ export class PlayerHandler
         const isTimeout = neededTurnTime > this.maxTurnTimeMs;
         if (isTimeout)
         {
-            console.error(`Player "${player.name}" exceeded max turn time.`);
+            console.error(`Player "${player.name}" exceeded max turn time by ${neededTurnTime - this.maxTurnTimeMs}ms`);
 
             this.statistician.recordWin(otherPlayer);
             // TODO: Should we record timeouts in the statistics?

--- a/src/backend/communication/playerHandler.ts
+++ b/src/backend/communication/playerHandler.ts
@@ -208,15 +208,6 @@ export class PlayerHandler
                 player.colour = otherPlayer.colour;
                 otherPlayer.colour = playerColour;
 
-                if (player.colour === Colour.White)
-                {
-                    player.stopWatchTime = Date.now();
-                }
-                else
-                {
-                    otherPlayer.stopWatchTime = Date.now();
-                }
-
                 const newGameMessagePlayer = new Messages.NewGameMessage(player.colour);
                 this.sendMessage(player, newGameMessagePlayer);
 
@@ -300,7 +291,6 @@ export class PlayerHandler
                     }
             }
 
-            otherPlayer.stopWatchTime = Date.now();
 
             return true;
         }
@@ -326,6 +316,7 @@ export class PlayerHandler
     {
         const messageString = message.compose();
 
+        player.stopWatchTime = Date.now();
         player.socket.write(messageString + '\n');
     }
 }

--- a/src/backend/communication/playerHandler.ts
+++ b/src/backend/communication/playerHandler.ts
@@ -164,7 +164,7 @@ export class PlayerHandler
 
         let moveWasSuccessful = true;
 
-        const neededTurnTime = player.stopWatchTime - Date.now();
+        const neededTurnTime = Date.now() - player.stopWatchTime;
         const isTimeout = neededTurnTime > this.maxTurnTimeMs;
         if (isTimeout)
         {

--- a/src/backend/communication/playerHandler.ts
+++ b/src/backend/communication/playerHandler.ts
@@ -168,7 +168,7 @@ export class PlayerHandler
         const isTimeout = neededTurnTime > this.maxTurnTimeMs;
         if (isTimeout)
         {
-            console.error(`Player "${player.name}" exceeded max turn time by ${neededTurnTime - this.maxTurnTimeMs}ms`);
+            console.error(`Player "${player.name}" exceeded max turn time by ${neededTurnTime - this.maxTurnTimeMs}ms.`);
 
             this.statistician.recordWin(otherPlayer);
             // TODO: Should we record timeouts in the statistics?


### PR DESCRIPTION
This PR improves the handling of timeouts by the PlayerHandler. It
- fixes a sign error in the calculation of the turn time
- logs the excess time if the maximum turn time was exceeded
- fixes the initialisation of the stopWatchTime